### PR TITLE
Remove pkg resources deprecations

### DIFF
--- a/fs/__init__.py
+++ b/fs/__init__.py
@@ -1,8 +1,6 @@
 """Python filesystem abstraction layer.
 """
 
-__import__("pkg_resources").declare_namespace(__name__)  # type: ignore
-
 from . import path
 from ._fscompat import fsdecode, fsencode
 from ._version import __version__

--- a/fs/opener/__init__.py
+++ b/fs/opener/__init__.py
@@ -2,9 +2,6 @@
 """Open filesystems from a URL.
 """
 
-# Declare fs.opener as a namespace package
-__import__("pkg_resources").declare_namespace(__name__)  # type: ignore
-
 # Import opener modules so that `registry.install` if called on each opener
 from . import appfs, ftpfs, memoryfs, osfs, tarfs, tempfs, zipfs
 

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -8,7 +8,7 @@ import typing
 
 import collections
 import contextlib
-import pkg_resources
+from importlib.metadata import entry_points
 
 from ..errors import ResourceReadOnly
 from .base import Opener
@@ -74,9 +74,10 @@ class Registry(object):
         """`list`: the list of supported protocols."""
         _protocols = list(self._protocols)
         if self.load_extern:
+            eps = entry_points()
             _protocols.extend(
                 entry_point.name
-                for entry_point in pkg_resources.iter_entry_points("fs.opener")
+                for entry_point in eps.get("fs.opener") or []
             )
             _protocols = list(collections.OrderedDict.fromkeys(_protocols))
         return _protocols
@@ -102,9 +103,11 @@ class Registry(object):
         protocol = protocol or self.default_opener
 
         if self.load_extern:
+            eps = entry_points(group="fs.opener")
             entry_point = next(
-                pkg_resources.iter_entry_points("fs.opener", protocol), None
+                (ep for ep in eps if ep.name == protocol), None
             )
+
         else:
             entry_point = None
 

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -167,7 +167,7 @@ class TestMove(unittest.TestCase):
             self.assertFalse(src.exists("target.txt"))
             self.assertFalse(dst.exists("file.txt"))
             self.assertTrue(dst.exists("target.txt"))
-            self.assertEquals(dst.readtext("target.txt"), "source content")
+            self.assertEqual(dst.readtext("target.txt"), "source content")
 
     @parameterized.expand([("temp", "temp://"), ("mem", "mem://")])
     def test_move_file_overwrite_itself(self, _, fs_url):
@@ -177,7 +177,7 @@ class TestMove(unittest.TestCase):
             tmp.writetext("file.txt", "content")
             fs.move.move_file(tmp, "file.txt", tmp, "file.txt")
             self.assertTrue(tmp.exists("file.txt"))
-            self.assertEquals(tmp.readtext("file.txt"), "content")
+            self.assertEqual(tmp.readtext("file.txt"), "content")
 
     @parameterized.expand([("temp", "temp://"), ("mem", "mem://")])
     def test_move_file_overwrite_itself_relpath(self, _, fs_url):
@@ -188,7 +188,7 @@ class TestMove(unittest.TestCase):
             new_dir.writetext("file.txt", "content")
             fs.move.move_file(tmp, "dir/../dir/file.txt", tmp, "dir/file.txt")
             self.assertTrue(tmp.exists("dir/file.txt"))
-            self.assertEquals(tmp.readtext("dir/file.txt"), "content")
+            self.assertEqual(tmp.readtext("dir/file.txt"), "content")
 
     @parameterized.expand([(True,), (False,)])
     def test_move_file_cleanup_on_error(self, cleanup):

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 import sys
 
 import os
-import pkg_resources
+import importlib.metadata
+
 import shutil
 import tempfile
 import unittest
@@ -13,6 +14,7 @@ from fs.appfs import UserDataFS
 from fs.memoryfs import MemoryFS
 from fs.opener import errors, registry
 from fs.opener.parse import ParseResult
+
 from fs.opener.registry import Registry
 from fs.osfs import OSFS
 
@@ -111,13 +113,15 @@ class TestRegistry(unittest.TestCase):
 
     def test_registry_protocols(self):
         # Check registry.protocols list the names of all available extension
-        extensions = [
-            pkg_resources.EntryPoint("proto1", "mod1"),
-            pkg_resources.EntryPoint("proto2", "mod2"),
-        ]
+        extensions = {
+            "fs.opener": [
+                importlib.metadata.EntryPoint("proto1", "mod1", "test"),
+                importlib.metadata.EntryPoint("proto2", "mod2", "test"),
+            ]
+        }
         m = mock.MagicMock(return_value=extensions)
         with mock.patch.object(
-            sys.modules["pkg_resources"], "iter_entry_points", new=m
+            sys.modules["fs.opener.registry"], "entry_points", new=m
         ):
             self.assertIn("proto1", opener.registry.protocols)
             self.assertIn("proto2", opener.registry.protocols)
@@ -129,11 +133,12 @@ class TestRegistry(unittest.TestCase):
     def test_entry_point_load_error(self):
 
         entry_point = mock.MagicMock()
+        entry_point.name = "test"
         entry_point.load.side_effect = ValueError("some error")
 
-        iter_entry_points = mock.MagicMock(return_value=iter([entry_point]))
+        entry_points = mock.MagicMock(return_value=iter([entry_point]))
 
-        with mock.patch("pkg_resources.iter_entry_points", iter_entry_points):
+        with mock.patch("fs.opener.registry.entry_points", entry_points):
             with self.assertRaises(errors.EntryPointError) as ctx:
                 opener.open_fs("test://")
             self.assertEqual(
@@ -145,10 +150,11 @@ class TestRegistry(unittest.TestCase):
             pass
 
         entry_point = mock.MagicMock()
+        entry_point.name = "test"
         entry_point.load = mock.MagicMock(return_value=NotAnOpener)
-        iter_entry_points = mock.MagicMock(return_value=iter([entry_point]))
+        entry_points = mock.MagicMock(return_value=iter([entry_point]))
 
-        with mock.patch("pkg_resources.iter_entry_points", iter_entry_points):
+        with mock.patch("fs.opener.registry.entry_points", entry_points):
             with self.assertRaises(errors.EntryPointError) as ctx:
                 opener.open_fs("test://")
             self.assertEqual("entry point did not return an opener", str(ctx.exception))
@@ -162,10 +168,11 @@ class TestRegistry(unittest.TestCase):
                 pass
 
         entry_point = mock.MagicMock()
+        entry_point.name = "test"
         entry_point.load = mock.MagicMock(return_value=BadOpener)
-        iter_entry_points = mock.MagicMock(return_value=iter([entry_point]))
+        entry_points = mock.MagicMock(return_value=iter([entry_point]))
 
-        with mock.patch("pkg_resources.iter_entry_points", iter_entry_points):
+        with mock.patch("fs.opener.registry.entry_points", entry_points):
             with self.assertRaises(errors.EntryPointError) as ctx:
                 opener.open_fs("test://")
             self.assertEqual(
@@ -214,12 +221,6 @@ class TestOpeners(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
-
-    def test_repr(self):
-        # Check __repr__ works
-        for entry_point in pkg_resources.iter_entry_points("fs.opener"):
-            _opener = entry_point.load()
-            repr(_opener())
 
     def test_open_osfs(self):
         fs = opener.open_fs("osfs://.")


### PR DESCRIPTION
Introduced changes according to deprecation warnings:

- DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
- DeprecationWarning: Deprecated call to pkg_resources.declare_namespace('fs').

Fixes: [#2959](https://github.com/Lundalogik/lime-core/issues/2959)